### PR TITLE
update GitHub actions in CI workflows 

### DIFF
--- a/.github/workflows/combine-config.yml
+++ b/.github/workflows/combine-config.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 


### PR DESCRIPTION
Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0