### PR TITLE
fix arbitrum euler integration url

### DIFF
--- a/protocols/euler/config.yaml
+++ b/protocols/euler/config.yaml
@@ -82,14 +82,14 @@ metadata:
     - chainId: 42161
       address: '0x936f210d277bf489a3211cef9ab4bc47a7b69c96'
       integrationUrl: >-
-        https://app.euler.finance/borrow?liquidity=&collateralAsset=PT-sUSDai-20NOV2025&network=arbitrum
+        https://app.euler.finance/borrow?liquidity=&collateralAsset=PT-sUSDai-20NOV2025&network=arbitrumone
       description: >-
         PT-sUSDai-20NOV2025 can be used as collateral to borrow or multiply
         against a variety of assets within Euler Yield
     - chainId: 42161
       address: '0x8b4ca42bb3b1d789859f106222cf7dc5eed48ccb'
       integrationUrl: >-
-        https://app.euler.finance/borrow?liquidity=&collateralAsset=PT-USDai-20NOV2025&network=arbitrum
+        https://app.euler.finance/borrow?liquidity=&collateralAsset=PT-USDai-20NOV2025&network=arbitrumone
       description: >-
         PT-USDai-20NOV2025 can be used as collateral to borrow or multiply
         against a variety of assets within Euler Yield
@@ -131,7 +131,7 @@ metadata:
     - chainId: 42161
       address: '0x5a791652f3b140d357df072d355a98ab754877d1'
       integrationUrl: >-
-        https://app.euler.finance/borrow?liquidity=&collateralAsset=PT-thBILL-27NOV2025&network=arbitrum
+        https://app.euler.finance/borrow?liquidity=&collateralAsset=PT-thBILL-27NOV2025&network=arbitrumone
       description: >-
         PT-thBILL-27NOV2025 can be used as collateral to borrow or multiply
         against a variety of assets within Euler Yield


### PR DESCRIPTION
**PR Checklist**

- [x] My protocol folder name must be **kebab-case**.
- [x] I have set all necessary fields like the example in [README file](https://github.com/pendle-finance/external-integration/blob/main/README.md).
- [x] My protocol's icon is a **png** image and smaller than **20KB**.
- [x] I have set asset addresses correctly according to their types (PT token address for PT integrations, LP token address for LP integration, etc).
- [x] I have set the integration URL valid and it points to the appropriate page.
- [x] I did not change the global config.json file. This file will be automatically generated.