### PR TITLE
chore(ci): SHA-pin actions/checkout to v6.0.2 (follow-up to prior major-tag upgrade)

### DIFF
--- a/.github/workflows/combine-config.yml
+++ b/.github/workflows/combine-config.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

Follow-up to the prior `actions/checkout` upgrade that landed with major-tag `@v6`. Converts all in-scope references in this repo to SHA-pinned form: `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2`.

## Context

This repo's workflows already moved from `@v4`/`@v3`/`@v2` to `@v6` in a prior PR. The workspace-wide policy (documented in the original sweep plan) was to SHA-pin all references for supply-chain hardening. Due to a race between the force-push tightening and the PR merge, the original PR landed with the major-tag `@v6` rather than the SHA-pinned form. This PR completes the intended tightening.

## Why SHA-pin?

`actions/checkout@v6` is a moving tag — the maintainer of `actions/checkout` (or an attacker who compromises that repo) can move the tag to a different commit. Pinning to the commit SHA (`de0fac2e...`) eliminates that attack surface: the SHA is content-addressable and cannot be silently changed.

Trade-off: future patch releases (`v6.0.3`, etc.) require manual SHA bumps. Mitigation: Dependabot for the github-actions ecosystem (separate sweep) would auto-PR future bumps and eliminate the manual burden.

## What changed

`.github/workflows/` only — version reference is the only change per `actions/checkout` line. All `with:` block arguments preserved unchanged.

## Test plan

- [ ] CI passes on this PR
- [ ] No `actions/checkout` deprecation warnings in workflow logs (v6.0.2 is Node 24 — same as `@v6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)