### PR TITLE
feat: dynamic-chain generators for Morpho & Aave (v3 + v4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,16 @@ Please ensure that:
  - The integration URL is valid and points to the appropriate page.
  - The protocol folder name must be **kebab-case**.
  - **Do not** change the global `config.json` file. This file will be automatically generated.
+
+## Script-generated protocols
+
+Some protocols keep a `script.md` next to their `config.yaml`. For these, the
+`config.yaml` is **generated** by running that script, not hand-edited — the
+script discovers the protocol's Pendle-PT markets across every Pendle-supported
+chain automatically (via the `getSupportChains` endpoint), so new chains and
+markets flow in without editing a per-chain list. When their markets change,
+**regenerate** the config by running the script rather than editing the YAML by
+hand:
+
+ - `protocols/morpho` — Morpho markets using Pendle PTs as collateral.
+ - `protocols/aave` — Aave v3 + v4 markets using Pendle PTs as collateral.

--- a/protocols/aave/config.yaml
+++ b/protocols/aave/config.yaml
@@ -4,44 +4,242 @@ category: Money Market
 description: >-
   Aave is a decentralised non-custodial liquidity protocol where users can
   participate as suppliers or borrowers
-url: 'https://app.aave.com/'
+url: https://app.aave.com/
 metadata:
   pt:
-    - chainId: 9745
-      address: '0xf7fb83435f455bd970f2d9f943f4eece1941b3e9'
-      subtitle: USDe
+    - chainId: 1
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
+      subtitle: DAI
       integrationUrl: >-
-        https://app.aave.com/reserve-overview/?underlyingAsset=0xf7fb83435f455bd970f2d9f943f4eece1941b3e9&marketName=proto_plasma_v3
-      description: PT-sUSDE-22OCT2026 can be used as collateral to borrow USDe on Aave
-    - chainId: 9745
-      address: '0xf7fb83435f455bd970f2d9f943f4eece1941b3e9'
-      subtitle: USDT0
-      integrationUrl: >-
-        https://app.aave.com/reserve-overview/?underlyingAsset=0xf7fb83435f455bd970f2d9f943f4eece1941b3e9&marketName=proto_plasma_v3
-      description: PT-sUSDE-22OCT2026 can be used as collateral to borrow USDT0 on Aave
-    - chainId: 9745
-      address: '0xf7fb83435f455bd970f2d9f943f4eece1941b3e9'
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow DAI on Aave
+    - chainId: 1
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
       subtitle: GHO
       integrationUrl: >-
-        https://app.aave.com/reserve-overview/?underlyingAsset=0xf7fb83435f455bd970f2d9f943f4eece1941b3e9&marketName=proto_plasma_v3
-      description: PT-sUSDE-22OCT2026 can be used as collateral to borrow GHO on Aave
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow GHO on Aave
     - chainId: 1
-      address: '0x59bc9fae5d62b19d4f8d07d758047acb9ee19d34'
-      subtitle: USDT
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
+      subtitle: RLUSD
       integrationUrl: >-
-        https://app.aave.com/reserve-overview/?underlyingAsset=0x59bc9fae5d62b19d4f8d07d758047acb9ee19d34&marketName=proto_ethereum_v3
-      description: PT-srUSDe-22OCT2026 can be used as collateral to borrow USDT on Aave
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow RLUSD on Aave
     - chainId: 1
-      address: '0x59bc9fae5d62b19d4f8d07d758047acb9ee19d34'
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
       subtitle: USDC
       integrationUrl: >-
-        https://app.aave.com/reserve-overview/?underlyingAsset=0x59bc9fae5d62b19d4f8d07d758047acb9ee19d34&marketName=proto_ethereum_v3
-      description: PT-srUSDe-22OCT2026 can be used as collateral to borrow USDC on Aave
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow USDC on Aave
     - chainId: 1
-      address: '0x59bc9fae5d62b19d4f8d07d758047acb9ee19d34'
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
       subtitle: USDe
       integrationUrl: >-
-        https://app.aave.com/reserve-overview/?underlyingAsset=0x59bc9fae5d62b19d4f8d07d758047acb9ee19d34&marketName=proto_ethereum_v3
-      description: PT-srUSDe-22OCT2026 can be used as collateral to borrow USDe on Aave
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 1
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
+      subtitle: USDG
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow USDG on Aave
+    - chainId: 1
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
+      subtitle: USDS
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow USDS on Aave
+    - chainId: 1
+      address: '0x1f84a51296691320478c98b8d77f2bbd17d34350'
+      subtitle: USDT
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x1f84a51296691320478c98b8d77f2bbd17d34350&marketName=proto_ethereum_v3
+      description: PT-USDe-5FEB2026 can be used as collateral to borrow USDT on Aave
+    - chainId: 1
+      address: '0x3de0ff76e8b528c092d47b9dac775931cef80f49'
+      subtitle: GHO
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjox
+      description: PT-sUSDE-7MAY2026 can be used as collateral to borrow GHO on Aave
+    - chainId: 1
+      address: '0x3de0ff76e8b528c092d47b9dac775931cef80f49'
+      subtitle: USDC
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjox
+      description: PT-sUSDE-7MAY2026 can be used as collateral to borrow USDC on Aave
+    - chainId: 1
+      address: '0x3de0ff76e8b528c092d47b9dac775931cef80f49'
+      subtitle: USDe
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjox
+      description: PT-sUSDE-7MAY2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 1
+      address: '0x3de0ff76e8b528c092d47b9dac775931cef80f49'
+      subtitle: USDT
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjox
+      description: PT-sUSDE-7MAY2026 can be used as collateral to borrow USDT on Aave
+    - chainId: 1
+      address: '0xaebf0bb9f57e89260d57f31af34eb58657d96ce0'
+      subtitle: GHO
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjow
+      description: PT-USDe-7MAY2026 can be used as collateral to borrow GHO on Aave
+    - chainId: 1
+      address: '0xaebf0bb9f57e89260d57f31af34eb58657d96ce0'
+      subtitle: USDC
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjow
+      description: PT-USDe-7MAY2026 can be used as collateral to borrow USDC on Aave
+    - chainId: 1
+      address: '0xaebf0bb9f57e89260d57f31af34eb58657d96ce0'
+      subtitle: USDe
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjow
+      description: PT-USDe-7MAY2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 1
+      address: '0xaebf0bb9f57e89260d57f31af34eb58657d96ce0'
+      subtitle: USDT
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHhiYTFCM0Q1NUQyNDk2OTJiNjY5QTE2NDAyNEE4MzgzMDlCNzUwOEFGOjow
+      description: PT-USDe-7MAY2026 can be used as collateral to borrow USDT on Aave
+    - chainId: 1
+      address: '0xc1906aecf868749a2dee203f59b904c0cf212140'
+      subtitle: USDC
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHg5NTZkOGUwQTg5Y2ZhMzc0NDQyOEM0NjQxYjVhNTNCNTYxNjdhN2Y5Ojow
+      description: PT-USDG-24SEP2026 can be used as collateral to borrow USDC on Aave
+    - chainId: 1
+      address: '0xc1906aecf868749a2dee203f59b904c0cf212140'
+      subtitle: USDG
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHg5NTZkOGUwQTg5Y2ZhMzc0NDQyOEM0NjQxYjVhNTNCNTYxNjdhN2Y5Ojow
+      description: PT-USDG-24SEP2026 can be used as collateral to borrow USDG on Aave
+    - chainId: 1
+      address: '0xc1906aecf868749a2dee203f59b904c0cf212140'
+      subtitle: USDT
+      integrationUrl: >-
+        https://pro.aave.com/explore/reserve/MTo6MHg5NTZkOGUwQTg5Y2ZhMzc0NDQyOEM0NjQxYjVhNTNCNTYxNjdhN2Y5Ojow
+      description: PT-USDG-24SEP2026 can be used as collateral to borrow USDT on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: DAI
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow DAI on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: GHO
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow GHO on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: RLUSD
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow RLUSD on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow USDC on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: USDe
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: USDG
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow USDG on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: USDS
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow USDS on Aave
+    - chainId: 1
+      address: '0xe8483517077afa11a9b07f849cee2552f040d7b2'
+      subtitle: USDT
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xe8483517077afa11a9b07f849cee2552f040d7b2&marketName=proto_ethereum_v3
+      description: PT-sUSDE-5FEB2026 can be used as collateral to borrow USDT on Aave
+    - chainId: 9745
+      address: '0x02fcc4989b4c9d435b7ced3fe1ba4cf77bbb5dd8'
+      subtitle: GHO
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x02fcc4989b4c9d435b7ced3fe1ba4cf77bbb5dd8&marketName=proto_plasma_v3
+      description: PT-sUSDE-15JAN2026 can be used as collateral to borrow GHO on Aave
+    - chainId: 9745
+      address: '0x02fcc4989b4c9d435b7ced3fe1ba4cf77bbb5dd8'
+      subtitle: USDe
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x02fcc4989b4c9d435b7ced3fe1ba4cf77bbb5dd8&marketName=proto_plasma_v3
+      description: PT-sUSDE-15JAN2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 9745
+      address: '0x02fcc4989b4c9d435b7ced3fe1ba4cf77bbb5dd8'
+      subtitle: USDT0
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x02fcc4989b4c9d435b7ced3fe1ba4cf77bbb5dd8&marketName=proto_plasma_v3
+      description: PT-sUSDE-15JAN2026 can be used as collateral to borrow USDT0 on Aave
+    - chainId: 9745
+      address: '0x54dc267be2839303ff1e323584a16e86cec4aa44'
+      subtitle: GHO
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x54dc267be2839303ff1e323584a16e86cec4aa44&marketName=proto_plasma_v3
+      description: PT-USDe-9APR2026 can be used as collateral to borrow GHO on Aave
+    - chainId: 9745
+      address: '0x54dc267be2839303ff1e323584a16e86cec4aa44'
+      subtitle: USDe
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x54dc267be2839303ff1e323584a16e86cec4aa44&marketName=proto_plasma_v3
+      description: PT-USDe-9APR2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 9745
+      address: '0x54dc267be2839303ff1e323584a16e86cec4aa44'
+      subtitle: USDT0
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x54dc267be2839303ff1e323584a16e86cec4aa44&marketName=proto_plasma_v3
+      description: PT-USDe-9APR2026 can be used as collateral to borrow USDT0 on Aave
+    - chainId: 9745
+      address: '0x93b544c330f60a2aa05ced87aeeffb8d38fd8c9a'
+      subtitle: GHO
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x93b544c330f60a2aa05ced87aeeffb8d38fd8c9a&marketName=proto_plasma_v3
+      description: PT-USDe-15JAN2026 can be used as collateral to borrow GHO on Aave
+    - chainId: 9745
+      address: '0x93b544c330f60a2aa05ced87aeeffb8d38fd8c9a'
+      subtitle: USDe
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x93b544c330f60a2aa05ced87aeeffb8d38fd8c9a&marketName=proto_plasma_v3
+      description: PT-USDe-15JAN2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 9745
+      address: '0x93b544c330f60a2aa05ced87aeeffb8d38fd8c9a'
+      subtitle: USDT0
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0x93b544c330f60a2aa05ced87aeeffb8d38fd8c9a&marketName=proto_plasma_v3
+      description: PT-USDe-15JAN2026 can be used as collateral to borrow USDT0 on Aave
+    - chainId: 9745
+      address: '0xab509448ad489e2e1341e25cc500f2596464cc82'
+      subtitle: GHO
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xab509448ad489e2e1341e25cc500f2596464cc82&marketName=proto_plasma_v3
+      description: PT-sUSDE-9APR2026 can be used as collateral to borrow GHO on Aave
+    - chainId: 9745
+      address: '0xab509448ad489e2e1341e25cc500f2596464cc82'
+      subtitle: USDe
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xab509448ad489e2e1341e25cc500f2596464cc82&marketName=proto_plasma_v3
+      description: PT-sUSDE-9APR2026 can be used as collateral to borrow USDe on Aave
+    - chainId: 9745
+      address: '0xab509448ad489e2e1341e25cc500f2596464cc82'
+      subtitle: USDT0
+      integrationUrl: >-
+        https://app.aave.com/reserve-overview/?underlyingAsset=0xab509448ad489e2e1341e25cc500f2596464cc82&marketName=proto_plasma_v3
+      description: PT-sUSDE-9APR2026 can be used as collateral to borrow USDT0 on Aave
   yt: []
   lp: []

--- a/protocols/aave/script.md
+++ b/protocols/aave/script.md
@@ -1,0 +1,380 @@
+// Aave integration generator (Aave v3 + v4).
+//
+// Regenerates protocols/aave/config.yaml from live data. Run it and copy the
+// stdout into config.yaml (stderr carries progress + loud warnings):
+//
+//   npx ts-node script.ts > config.yaml
+//
+// Chains are derived DYNAMICALLY from Pendle's getSupportChains endpoint,
+// intersected per protocol with Aave's own supported-chain list. For each PT
+// that Aave accepts as collateral, one row is emitted per major borrowable
+// stablecoin (STABLE_BORROW) in that market/spoke — matching the shape of the
+// previously hand-maintained config. Every emitted PT is cross-checked against
+// Pendle's simplified-data list (CI parity) and the run fails loud (emits
+// nothing) on any API/empty-response error.
+//
+// v3 (api.v3.aave.com): rich schema — symbols, markets, collateral/borrow flags
+//   all available. URL: app.aave.com/reserve-overview/?underlyingAsset&marketName
+// v4 (api.v4.aave.com): hub/spoke model, and its GraphQL exposes NO token
+//   symbols. Symbols are resolved from a dictionary built out of the v3 reserves
+//   plus Pendle's asset registry (assets/all) — a v4 token with no resolvable
+//   symbol is skipped LOUDLY, never guessed. URL: pro.aave.com/explore/reserve/{id}
+//   (the reserve `id` is exactly the app's base64 route param).
+
+import * as yaml from 'js-yaml';
+
+const PENDLE_CHAINS_URL =
+  'https://api-v2.pendle.finance/core/v1/chains?includeAdditional=true';
+const PENDLE_ASSETS_URL =
+  'https://api-v2.pendle.finance/core/v1/querier/simplified-data';
+const AAVE_V3_GRAPHQL = 'https://api.v3.aave.com/graphql';
+const AAVE_V4_GRAPHQL = 'https://api.v4.aave.com/graphql';
+
+// Borrow assets shown per PT collateral. PTs are yield-stablecoin collateral, so
+// we surface the major borrowable stablecoins. Edit this set to widen/narrow
+// which borrow targets appear.
+const STABLE_BORROW = new Set([
+  'USDC',
+  'USDT',
+  'USDT0',
+  'USDe',
+  'GHO',
+  'USDG',
+  'USDS',
+  'DAI',
+  'RLUSD',
+]);
+
+// Aave v3 market name -> reserve-overview `marketName` slug. A PT-collateral
+// market not mapped here is skipped LOUDLY (never guessed).
+const AAVE_V3_MARKET_NAME: Record<string, string> = {
+  AaveV3Ethereum: 'proto_ethereum_v3',
+  AaveV3Plasma: 'proto_plasma_v3',
+};
+
+const DESCRIPTION_MAX = 120;
+const isPt = (sym?: string): boolean => /^pt-/i.test(sym ?? '');
+
+interface PtRow {
+  chainId: number;
+  address: string;
+  subtitle: string;
+  integrationUrl: string;
+  description: string;
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.json() as Promise<T>;
+}
+
+async function gql<T>(endpoint: string, query: string): Promise<T> {
+  const body = await fetchJson<{ data: T; errors?: unknown }>(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
+  if (body.errors) {
+    throw new Error(`GraphQL error (${endpoint}): ${JSON.stringify(body.errors)}`);
+  }
+  return body.data;
+}
+
+async function getSupportedChainIds(): Promise<number[]> {
+  const { chainIds } = await fetchJson<{ chainIds: number[] }>(PENDLE_CHAINS_URL);
+  if (!Array.isArray(chainIds) || chainIds.length === 0) {
+    throw new Error('getSupportChains returned an empty/invalid chain list');
+  }
+  return chainIds;
+}
+
+async function getPendlePtSet(): Promise<Set<string>> {
+  const { data } = await fetchJson<{
+    data: Array<{ chainId: number; pts?: string[]; crossPts?: Array<{ spokePt: string }> }>;
+  }>(PENDLE_ASSETS_URL);
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error('simplified-data returned an empty/invalid asset list');
+  }
+  const set = new Set<string>();
+  for (const { chainId, pts, crossPts } of data) {
+    (pts ?? []).forEach((pt) => set.add(`${chainId}-${pt.toLowerCase()}`));
+    (crossPts ?? []).forEach((c) => set.add(`${chainId}-${c.spokePt.toLowerCase()}`));
+  }
+  return set;
+}
+
+// address -> symbol across the given chains, from Pendle's asset registry.
+// Needed because Aave v4 exposes no token symbols and some v4-only PTs are
+// absent from the v3 dictionary.
+async function getPendleSymbols(chainIds: number[]): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  for (const chainId of chainIds) {
+    let assets: Array<{ address?: string; symbol?: string }>;
+    try {
+      assets = await fetchJson(
+        `https://api-v2.pendle.finance/core/v1/${chainId}/assets/all`,
+      );
+    } catch {
+      continue; // not a Pendle core chain; skip quietly
+    }
+    for (const a of assets) {
+      if (a.address && a.symbol) map.set(`${chainId}-${a.address.toLowerCase()}`, a.symbol);
+    }
+  }
+  return map;
+}
+
+function pushRow(
+  rows: PtRow[],
+  x: { chainId: number; address: string; subtitle: string; integrationUrl: string; ptSymbol: string },
+): void {
+  const description = `${x.ptSymbol} can be used as collateral to borrow ${x.subtitle} on Aave`;
+  if (description.length > DESCRIPTION_MAX) {
+    console.error(`WARN description >${DESCRIPTION_MAX}, skipped: ${x.ptSymbol}/${x.subtitle}`);
+    return;
+  }
+  rows.push({
+    chainId: x.chainId,
+    address: x.address.toLowerCase(),
+    subtitle: x.subtitle,
+    integrationUrl: x.integrationUrl,
+    description,
+  });
+}
+
+// ---- Aave v3 ---------------------------------------------------------------
+interface V3Reserve {
+  underlyingToken: { address: string; symbol: string };
+  supplyInfo: { canBeCollateral: boolean } | null;
+  borrowInfo: { borrowingState: string } | null;
+}
+interface V3Market {
+  name: string;
+  chain: { chainId: number };
+  reserves: V3Reserve[];
+}
+
+async function aaveV3ChainIds(): Promise<number[]> {
+  const data = await gql<{ chains: Array<{ chainId: number }> }>(
+    AAVE_V3_GRAPHQL,
+    '{ chains(filter: ALL) { chainId } }',
+  );
+  return data.chains.map((c) => c.chainId);
+}
+
+// Returns { rows, symbolByAddr }; symbolByAddr seeds v4 symbol resolution.
+async function generateV3(
+  pendleChains: number[],
+  ptSet: Set<string>,
+): Promise<{ rows: PtRow[]; symbolByAddr: Map<string, string> }> {
+  const v3Chains = await aaveV3ChainIds();
+  const chains = pendleChains.filter((c) => v3Chains.includes(c));
+  const data = await gql<{ markets: V3Market[] }>(
+    AAVE_V3_GRAPHQL,
+    `{ markets(request: { chainIds: [${chains.join(',')}] }) {
+        name
+        chain { chainId }
+        reserves {
+          underlyingToken { address symbol }
+          supplyInfo { canBeCollateral }
+          borrowInfo { borrowingState }
+        }
+      } }`,
+  );
+
+  const rows: PtRow[] = [];
+  const symbolByAddr = new Map<string, string>();
+  const skippedMarkets = new Set<string>();
+
+  for (const m of data.markets) {
+    const chainId = m.chain.chainId;
+    for (const r of m.reserves) {
+      symbolByAddr.set(
+        `${chainId}-${r.underlyingToken.address.toLowerCase()}`,
+        r.underlyingToken.symbol,
+      );
+    }
+
+    const borrowStables = m.reserves.filter(
+      (r) =>
+        r.borrowInfo?.borrowingState &&
+        r.borrowInfo.borrowingState !== 'DISABLED' &&
+        STABLE_BORROW.has(r.underlyingToken.symbol),
+    );
+    const pts = m.reserves.filter(
+      (r) => isPt(r.underlyingToken.symbol) && r.supplyInfo?.canBeCollateral,
+    );
+    if (!pts.length) continue;
+
+    const marketName = AAVE_V3_MARKET_NAME[m.name];
+    if (!marketName) {
+      skippedMarkets.add(`${m.name}(chain ${chainId})`);
+      continue;
+    }
+
+    for (const pt of pts) {
+      const address = pt.underlyingToken.address.toLowerCase();
+      if (!ptSet.has(`${chainId}-${address}`)) continue;
+      for (const b of borrowStables) {
+        pushRow(rows, {
+          chainId,
+          address,
+          subtitle: b.underlyingToken.symbol,
+          integrationUrl: `https://app.aave.com/reserve-overview/?underlyingAsset=${address}&marketName=${marketName}`,
+          ptSymbol: pt.underlyingToken.symbol,
+        });
+      }
+    }
+  }
+
+  if (skippedMarkets.size) {
+    console.error(
+      `WARN v3 PT markets on unmapped market(s) skipped (add to AAVE_V3_MARKET_NAME): ${[
+        ...skippedMarkets,
+      ].join(', ')}`,
+    );
+  }
+  return { rows, symbolByAddr };
+}
+
+// ---- Aave v4 ---------------------------------------------------------------
+interface V4Reserve {
+  id: string;
+  canUseAsCollateral: boolean;
+  canBorrow: boolean;
+  spoke: { id: string } | null;
+  asset: { underlying: { address: string } | null } | null;
+}
+
+async function aaveV4ChainIds(): Promise<number[]> {
+  const data = await gql<{ chains: Array<{ chainId: number }> }>(
+    AAVE_V4_GRAPHQL,
+    '{ chains(request: { query: { filter: ALL } }) { chainId } }',
+  );
+  return data.chains.map((c) => c.chainId);
+}
+
+async function generateV4(
+  pendleChains: number[],
+  ptSet: Set<string>,
+  symbolByAddr: Map<string, string>,
+): Promise<PtRow[]> {
+  const v4Chains = await aaveV4ChainIds();
+  const chains = pendleChains.filter((c) => v4Chains.includes(c));
+  const rows: PtRow[] = [];
+  const unresolved = new Set<string>();
+
+  for (const chainId of chains) {
+    const data = await gql<{ reserves: V4Reserve[] }>(
+      AAVE_V4_GRAPHQL,
+      `{ reserves(request: { query: { chainIds: [${chainId}] } }) {
+          id
+          canUseAsCollateral
+          canBorrow
+          spoke { id }
+          asset { underlying { address } }
+        } }`,
+    );
+
+    // Group reserves by spoke to find each spoke's borrowable stablecoins.
+    const bySpoke = new Map<string, V4Reserve[]>();
+    for (const r of data.reserves) {
+      const spoke = r.spoke?.id ?? 'none';
+      if (!bySpoke.has(spoke)) bySpoke.set(spoke, []);
+      bySpoke.get(spoke)!.push(r);
+    }
+
+    for (const r of data.reserves) {
+      if (!r.canUseAsCollateral) continue;
+      const address = r.asset?.underlying?.address?.toLowerCase();
+      const ptSymbol = address && symbolByAddr.get(`${chainId}-${address}`);
+      if (!address || !isPt(ptSymbol)) continue;
+      if (!ptSet.has(`${chainId}-${address}`)) continue;
+
+      const borrowStables = (bySpoke.get(r.spoke?.id ?? 'none') ?? []).filter((x) => {
+        if (!x.canBorrow) return false;
+        const a = x.asset?.underlying?.address?.toLowerCase();
+        const sym = a && symbolByAddr.get(`${chainId}-${a}`);
+        if (!sym) {
+          if (a) unresolved.add(`${chainId}-${a}`);
+          return false;
+        }
+        return STABLE_BORROW.has(sym);
+      });
+
+      for (const b of borrowStables) {
+        const sym = symbolByAddr.get(`${chainId}-${b.asset!.underlying!.address.toLowerCase()}`)!;
+        pushRow(rows, {
+          chainId,
+          address,
+          subtitle: sym,
+          integrationUrl: `https://pro.aave.com/explore/reserve/${r.id}`,
+          ptSymbol: ptSymbol as string,
+        });
+      }
+    }
+  }
+
+  if (unresolved.size) {
+    console.error(`WARN v4 borrow assets with no symbol (skipped): ${unresolved.size} tokens`);
+  }
+  return rows;
+}
+
+async function main(): Promise<void> {
+  const [pendleChains, ptSet] = await Promise.all([
+    getSupportedChainIds(),
+    getPendlePtSet(),
+  ]);
+
+  const { rows: v3Rows, symbolByAddr } = await generateV3(pendleChains, ptSet);
+  console.error(`v3: ${v3Rows.length} rows`);
+
+  // Union Pendle's asset registry into the symbol dict so v4-only PTs resolve.
+  const pendleSymbols = await getPendleSymbols(pendleChains);
+  for (const [k, v] of pendleSymbols) if (!symbolByAddr.has(k)) symbolByAddr.set(k, v);
+
+  const v4Rows = await generateV4(pendleChains, ptSet, symbolByAddr);
+  console.error(`v4: ${v4Rows.length} rows`);
+
+  // Merge + dedup on (chainId,address,subtitle): one row per PT + borrow asset.
+  // v3 precedes v4, so an established v3 market wins over a v4 spoke, and the v4
+  // hub/spoke model can't emit the same PT+borrow twice via different spokes.
+  const seen = new Set<string>();
+  const pt: PtRow[] = [];
+  for (const r of [...v3Rows, ...v4Rows]) {
+    const k = `${r.chainId}-${r.address}-${r.subtitle}`;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    pt.push(r);
+  }
+  pt.sort(
+    (a, b) =>
+      a.chainId - b.chainId ||
+      a.address.localeCompare(b.address) ||
+      a.subtitle.localeCompare(b.subtitle) ||
+      a.integrationUrl.localeCompare(b.integrationUrl),
+  );
+  console.error(
+    `Emitted ${pt.length} rows across chains ${[...new Set(pt.map((r) => r.chainId))].join(', ')}`,
+  );
+
+  const config = {
+    name: 'Aave',
+    icon: 'logo.png',
+    category: 'Money Market',
+    description:
+      'Aave is a decentralised non-custodial liquidity protocol where users can participate as suppliers or borrowers',
+    url: 'https://app.aave.com/',
+    metadata: { pt, yt: [], lp: [] },
+  };
+  process.stdout.write(yaml.dump(config, { lineWidth: 80, sortKeys: false, quotingType: "'" }));
+}
+
+// Fail loud: on any error, write nothing to stdout so a partial/empty config is
+// never produced.
+main().catch((err) => {
+  console.error('GENERATION FAILED (no output written):', err.message);
+  process.exit(1);
+});

--- a/protocols/aave/script.md
+++ b/protocols/aave/script.md
@@ -198,8 +198,7 @@ async function generateV3(
 
     const borrowStables = m.reserves.filter(
       (r) =>
-        r.borrowInfo?.borrowingState &&
-        r.borrowInfo.borrowingState !== 'DISABLED' &&
+        r.borrowInfo?.borrowingState === 'ENABLED' &&
         STABLE_BORROW.has(r.underlyingToken.symbol),
     );
     const pts = m.reserves.filter(
@@ -288,9 +287,14 @@ async function generateV4(
     for (const r of data.reserves) {
       if (!r.canUseAsCollateral) continue;
       const address = r.asset?.underlying?.address?.toLowerCase();
-      const ptSymbol = address && symbolByAddr.get(`${chainId}-${address}`);
-      if (!address || !isPt(ptSymbol)) continue;
-      if (!ptSet.has(`${chainId}-${address}`)) continue;
+      // Not a Pendle PT -> skip quietly. A Pendle PT with no resolvable symbol
+      // -> skip LOUDLY (should not happen once Pendle's registry is unioned in).
+      if (!address || !ptSet.has(`${chainId}-${address}`)) continue;
+      const ptSymbol = symbolByAddr.get(`${chainId}-${address}`);
+      if (!isPt(ptSymbol)) {
+        unresolved.add(`${chainId}-${address} (collateral PT symbol)`);
+        continue;
+      }
 
       const borrowStables = (bySpoke.get(r.spoke?.id ?? 'none') ?? []).filter((x) => {
         if (!x.canBorrow) return false;

--- a/protocols/morpho/config.yaml
+++ b/protocols/morpho/config.yaml
@@ -1,13 +1,181 @@
 name: Morpho
 icon: logo.png
 category: Money Market
-url: 'https://app.morpho.org/ethereum/borrow'
+url: https://app.morpho.org/ethereum/borrow
 description: >-
   A permissionless and non-custodial lending protocol where users can earn
   interest on over-collaterized lending and borrow digital assets using
   immutable infrastructure.
 metadata:
   pt:
+    - chainId: 1
+      address: '0x1d69402390657308c91179aa184bf992908c1e08'
+      subtitle: AUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x9464b3d42133c10c8b216d3d9429b43e98c2f3856a87940ef18b8bdd3e7bd831
+      description: >-
+        The PT-USDat-27AUG2026 is the asset used as collateral in a Morpho
+        market with AUSD as the loan token.
+    - chainId: 1
+      address: '0x1d69402390657308c91179aa184bf992908c1e08'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x69ef7fd17b42cd7df6d885aee1b11380837afbc1664b25587041cf193b31617b
+      description: >-
+        The PT-USDat-27AUG2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0x1fb3c5c35d95f48e48ffc8e36bcce5cb5f29f57c'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x79b4e55cef9e7c214b5cc965e1984229ada26a66051e35366a75c4d92b776735
+      description: >-
+        The PT-srUSDe-15JAN2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0x2d3c279e5fcdf5b793c0a75ed90738d7369b0b83'
+      subtitle: AUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x54e42432a7c0309ba650080cab6fcff377034fd9de174bbd3a4b519186ffc0f8
+      description: >-
+        The PT-stcUSD-23JUL2026 is the asset used as collateral in a Morpho
+        market with AUSD as the loan token.
+    - chainId: 1
+      address: '0x2d3c279e5fcdf5b793c0a75ed90738d7369b0b83'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x2fb3713487c7812e7309935b034f40228841666f6b048faf31fd2110ae674f20
+      description: >-
+        The PT-stcUSD-23JUL2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0x2d3c279e5fcdf5b793c0a75ed90738d7369b0b83'
+      subtitle: USDT
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x5eaaebc81e9e27972ab458811d1b60828e8ab51ef6620f9b3918fd7e68eecec1
+      description: >-
+        The PT-stcUSD-23JUL2026 is the asset used as collateral in a Morpho
+        market with USDT as the loan token.
+    - chainId: 1
+      address: '0x2d433b943fb8c015ae409444b7f960ed288082b4'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x42c2b592fc759fad461fb5c80d5ea214a496f70d8594398d69af68c2f3798de6
+      description: >-
+        The PT-srUSDat-27AUG2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0x3365554a61ceff74a76528f9e86c1e87946d16a5'
+      subtitle: apxUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x04663e98d677d8ef38b76d5a19d1fddc1aff10a86b71dc7f01cd8f5a18a16f06
+      description: >-
+        The PT-apyUSD-18JUN2026 is the asset used as collateral in a Morpho
+        market with apxUSD as the loan token.
+    - chainId: 1
+      address: '0x3365554a61ceff74a76528f9e86c1e87946d16a5'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xa75bb490ecfee90c86a9d22ebc2dde42fb83478b3f18722b9fc6f5f668cab124
+      description: >-
+        The PT-apyUSD-18JUN2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0x3b3fb9c57858ef816833dc91565efcd85d96f634'
+      subtitle: DAI
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xb81eaed0df42ff6646c8daf4fe38afab93b13b6a89c9750d08e705223a45e2ef
+      description: >-
+        The PT-sUSDE-31JUL2025 is the asset used as collateral in a Morpho
+        market with DAI as the loan token.
+    - chainId: 1
+      address: '0x3eaa0f0f0a5d3d595ae4e4b0d27f439d01c3e7b2'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x9bc98c2f20ac58287ef2c860eea53a2fdc27c17a7817ff1206c0b7840cc7cd79
+      description: >-
+        The PT-reUSD-25JUN2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0x3eaa0f0f0a5d3d595ae4e4b0d27f439d01c3e7b2'
+      subtitle: USDT
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x3fea56ab83b05840dc83dc6b3d2f2fbd938147cbaa8126bac529e6c820058253
+      description: >-
+        The PT-reUSD-25JUN2026 is the asset used as collateral in a Morpho
+        market with USDT as the loan token.
+    - chainId: 1
+      address: '0x545a490f9ab534adf409a2e682bc4098f49952e3'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x802ec6e878dc9fe6905b8a0a18962dcca10440a87fa2242fbf4a0461c7b0c789
+      description: >-
+        The PT-cUSD-29JAN2026 is the asset used as collateral in a Morpho market
+        with USDC as the loan token.
+    - chainId: 1
+      address: '0x5a19fa369f2895dcd8d2cee62e4ceae58ef92bbb'
+      subtitle: PYUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x80fea13225f27a1f4798c35d89e791711f963ed74eb3a86bcaffe28143095e94
+      description: >-
+        The PT-sUSDE-13AUG2026 is the asset used as collateral in a Morpho
+        market with PYUSD as the loan token.
+    - chainId: 1
+      address: '0x5a19fa369f2895dcd8d2cee62e4ceae58ef92bbb'
+      subtitle: RLUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x1749e02006bc6bd6a86af52d231511f6911d5e42318e028e51a28dfabc68dd47
+      description: >-
+        The PT-sUSDE-13AUG2026 is the asset used as collateral in a Morpho
+        market with RLUSD as the loan token.
+    - chainId: 1
+      address: '0x5dbf246b37e1b9ac5d08bb38233d71322ae7d166'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xdf034d0351a4c0af947e1a37ecd5ccbce60d72eac90de6fcad48c74e2869d14c
+      description: >-
+        The PT-iUSD-25JUN2026 is the asset used as collateral in a Morpho market
+        with USDC as the loan token.
+    - chainId: 1
+      address: '0x6ca4d5d2ecb72e3bbf17543b3367746b80d22694'
+      subtitle: LBTC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x35cab197d4eaeeea1e8e279ed136e193500e65ff68b4bf8af54f98d4923660eb
+      description: >-
+        The PT-LBTC-26JUN2025 is the asset used as collateral in a Morpho market
+        with LBTC as the loan token.
+    - chainId: 1
+      address: '0x6ca4d5d2ecb72e3bbf17543b3367746b80d22694'
+      subtitle: WBTC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xa67befc86e760d94b973ac3fe3489fcb55b5f897d8aefc1d292a9a4f44f48370
+      description: >-
+        The PT-LBTC-26JUN2025 is the asset used as collateral in a Morpho market
+        with WBTC as the loan token.
+    - chainId: 1
+      address: '0x7f47c3e6b2c00fc4eb4d5ae50d0ab0ab6888eb4d'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89
+      description: >-
+        The PT-USD3-17DEC2026 is the asset used as collateral in a Morpho market
+        with USDC as the loan token.
+    - chainId: 1
+      address: '0x917459337caac939d41d7493b3999f571d20d667'
+      subtitle: DAI
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x760b14c9003f08ac4bf0cfb02596ee4d6f0548a4fde5826bfd56befb9ed62ae9
+      description: >-
+        The PT-USDe-31JUL2025 is the asset used as collateral in a Morpho market
+        with DAI as the loan token.
+    - chainId: 1
+      address: '0x928fb6ed39100a92b2480f5cbb93453f98d9f4ce'
+      subtitle: AUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xe7f998c0ff11ca2bf091d39b6a3cef1035733528187d520c1c47710c8f1acaeb
+      description: >-
+        The PT-cUSD-23JUL2026 is the asset used as collateral in a Morpho market
+        with AUSD as the loan token.
     - chainId: 1
       address: '0x928fb6ed39100a92b2480f5cbb93453f98d9f4ce'
       subtitle: USDC
@@ -25,53 +193,53 @@ metadata:
         The PT-cUSD-23JUL2026 is the asset used as collateral in a Morpho market
         with USDT as the loan token.
     - chainId: 1
-      address: '0x2d3c279e5fcdf5b793c0a75ed90738d7369b0b83'
+      address: '0x92a6a01b07984de46c24e8eba248449beb8b1dcb'
+      subtitle: apxUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xf3814af4869a6ce59ffef016e555dd4c1e92bf383b5ab89abe496044c6364746
+      description: >-
+        The PT-apxUSD-18JUN2026 is the asset used as collateral in a Morpho
+        market with apxUSD as the loan token.
+    - chainId: 1
+      address: '0x92a6a01b07984de46c24e8eba248449beb8b1dcb'
       subtitle: USDC
       integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x2fb3713487c7812e7309935b034f40228841666f6b048faf31fd2110ae674f20
+        https://app.morpho.org/ethereum/market/0xed05fcc2893b78b3fa468d21b6e4d2925e7f2c64eb1f16279757c43f87502a99
       description: >-
-        The PT-stcUSD-23JUL2026 is the asset used as collateral in a Morpho
+        The PT-apxUSD-18JUN2026 is the asset used as collateral in a Morpho
         market with USDC as the loan token.
     - chainId: 1
-      address: '0x1d69402390657308c91179aa184bf992908c1e08'
+      address: '0x9db38d74a0d29380899ad354121dfb521adb0548'
       subtitle: AUSD
       integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x9464b3d42133c10c8b216d3d9429b43e98c2f3856a87940ef18b8bdd3e7bd831
+        https://app.morpho.org/ethereum/market/0x16f269c5cc745b486060d42e21aef2f33edfe4b8cf6dce95e518a789469aae78
       description: >-
-        The PT-USDat-27AUG2026 is the asset used as collateral in a Morpho
-        market with AUSD as the loan token.
+        The PT-USDG-28MAY2026 is the asset used as collateral in a Morpho market
+        with AUSD as the loan token.
     - chainId: 1
-      address: '0x1d69402390657308c91179aa184bf992908c1e08'
+      address: '0x9db38d74a0d29380899ad354121dfb521adb0548'
       subtitle: USDC
       integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x69ef7fd17b42cd7df6d885aee1b11380837afbc1664b25587041cf193b31617b
+        https://app.morpho.org/ethereum/market/0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553
       description: >-
-        The PT-USDat-27AUG2026 is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
-    - chainId: 130
-      address: '0x9d9874e867b877dd0a3f1eafb8bb1bc54eecc682'
-      subtitle: USDC
-      integrationUrl: >-
-        https://app.morpho.org/unichain/market/0x87a686cc100aabe917f8e1ad58140a1b63f0edbb9650a32c0526718dc610b2d5
-      description: >-
-        The PT-cUSD-23JUL2026-(ETH) is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
+        The PT-USDG-28MAY2026 is the asset used as collateral in a Morpho market
+        with USDC as the loan token.
     - chainId: 1
-      address: '0xd341a146a4fd20ea89898e4d86ae1829bf3a1c23'
-      subtitle: USDC
+      address: '0x9db38d74a0d29380899ad354121dfb521adb0548'
+      subtitle: USDT
       integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97
+        https://app.morpho.org/ethereum/market/0x1e6ff1bfeb04dd5680c58d24b48cfce57474bd97bcbfaa0d2cd8015bc40c4b52
       description: >-
-        The PT-sUSDD-27AUG2026 is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
+        The PT-USDG-28MAY2026 is the asset used as collateral in a Morpho market
+        with USDT as the loan token.
     - chainId: 1
-      address: '0xb5be35d8ff83d431899b95851cb17a2b4bcef150'
-      subtitle: USDC
+      address: '0xaf687b5ecb525ccea96115088999b4ed80c388b6'
+      subtitle: apxUSD
       integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0xb37c30f34bff11c81ee8400133965f450a5f7c5d81ba2cf5740076f49eabc95c
+        https://app.morpho.org/ethereum/market/0xd86df29b48f2d88a0453027212247a29e68ff52c6589c46054f57285da2fa7e3
       description: >-
-        The PT-apyUSD-5NOV2026 is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
+        The PT-apxUSD-5NOV2026 is the asset used as collateral in a Morpho
+        market with apxUSD as the loan token.
     - chainId: 1
       address: '0xaf687b5ecb525ccea96115088999b4ed80c388b6'
       subtitle: USDC
@@ -79,70 +247,6 @@ metadata:
         https://app.morpho.org/ethereum/market/0x908b037029b5c0671ba3b362eaf289c3199560d1d4632e6cb527cc7240fa006e
       description: >-
         The PT-apxUSD-5NOV2026 is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
-    - chainId: 1
-      address: '0x7f47c3e6b2c00fc4eb4d5ae50d0ab0ab6888eb4d'
-      subtitle: USDC
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89
-      description: >-
-        The PT-USD3-17DEC2026 is the asset used as collateral in a Morpho market
-        with USDC as the loan token.
-    - chainId: 1
-      address: '0xd341a146a4fd20ea89898e4d86ae1829bf3a1c23'
-      subtitle: USDT
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0xdf6ca97d41975a6996e9db491cb38152b65d7c00807dfe15d95d8d76e5d122e0
-      description: >-
-        The PT-sUSDD-27AUG2026 is the asset used as collateral in a Morpho
-        market with USDT as the loan token.
-    - chainId: 1
-      address: '0xc689f76f90fe1762fac55983ff25ae71033a84f7'
-      subtitle: USDC
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x4bb22a5f6313fc9d7b5e1438967bfcd0a513a839d26662dd8d235629942400e2
-      description: >-
-        The PT-sUSDat-27AUG2026 is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
-    - chainId: 1
-      address: '0x5a19fa369f2895dcd8d2cee62e4ceae58ef92bbb'
-      subtitle: RLUSD
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x1749e02006bc6bd6a86af52d231511f6911d5e42318e028e51a28dfabc68dd47
-      description: >-
-        The PT-sUSDE-13AUG2026 is the asset used as collateral in a Morpho
-        market with RLUSD as the loan token.
-    - chainId: 1
-      address: '0xecfafdc7741323a945a163ed068b5a3c43483957'
-      subtitle: USDC
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x1e9d614631a7df0ec07fb05b2c8cb2491575fd1a63a33bf187a6afb295a4fc64
-      description: >-
-        The PT-reUSD-10DEC2026 is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
-    - chainId: 1
-      address: '0xc1906aecf868749a2dee203f59b904c0cf212140'
-      subtitle: USDT
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x02bb03bf55f07c3ed3eee8a25d8df60fb9d09a38db612f0e07cf5c4d3df0100d
-      description: >-
-        The PT-USDG-24SEP2026 is the asset used as collateral in a Morpho market
-        with USDT as the loan token.
-    - chainId: 1
-      address: '0xee5c7cda577484b70b65c21235ecbd302bb290e2'
-      subtitle: USDC
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x62878115c6ee109c256237eb6daef589d006258202682d2e210cad3bb19e0f09
-      description: >-
-        The PT-apyUSD-27AUG2026 is the asset used as collateral in a Morpho
-        market with USDC as the loan token.
-    - chainId: 1
-      address: '0xd28b0d694b8e814fa905a8b480b30691e18396eb'
-      subtitle: USDC
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0x4483b864209c50da2be8fc75371db0e92fdc6bc8920d86fc9b56ea7383f8c9d1
-      description: >-
-        The PT-apxUSD-27AUG2026 is the asset used as collateral in a Morpho
         market with USDC as the loan token.
     - chainId: 1
       address: '0xb5be35d8ff83d431899b95851cb17a2b4bcef150'
@@ -153,21 +257,149 @@ metadata:
         The PT-apyUSD-5NOV2026 is the asset used as collateral in a Morpho
         market with apxUSD as the loan token.
     - chainId: 1
-      address: '0xaf687b5ecb525ccea96115088999b4ed80c388b6'
-      subtitle: apxUSD
-      integrationUrl: >-
-        https://app.morpho.org/ethereum/market/0xd86df29b48f2d88a0453027212247a29e68ff52c6589c46054f57285da2fa7e3
-      description: >-
-        The PT-apxUSD-5NOV2026 is the asset used as collateral in a Morpho
-        market with apxUSD as the loan token.
-    - chainId: 42161
-      address: '0xc9d24ad0bb25f34098e226a8c5192dea7bacccae'
+      address: '0xb5be35d8ff83d431899b95851cb17a2b4bcef150'
       subtitle: USDC
       integrationUrl: >-
-        https://app.morpho.org/arbitrum/market/0x97cb4b88a7a5e8e9c039b106374124e642395437ffc0ef93f2799343ad022985
+        https://app.morpho.org/ethereum/market/0xb37c30f34bff11c81ee8400133965f450a5f7c5d81ba2cf5740076f49eabc95c
       description: >-
-        The PT-USDai-15OCT2026 is the asset used as collateral in a Morpho
+        The PT-apyUSD-5NOV2026 is the asset used as collateral in a Morpho
         market with USDC as the loan token.
+    - chainId: 1
+      address: '0xbb6cdb98a2f8a9fb431fd1073eaa0a51422ac30d'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc
+      description: >-
+        The PT-siUSD-20AUG2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0xbc6736d346a5ebc0debc997397912cd9b8fae10a'
+      subtitle: USDT
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xb0a9ac81a8c6a5274aa1a8337aed35a2cb2cd4feb5c6d3b39d41f234fbf2955b
+      description: >-
+        The PT-USDe-25SEP2025 is the asset used as collateral in a Morpho market
+        with USDT as the loan token.
+    - chainId: 1
+      address: '0xc1906aecf868749a2dee203f59b904c0cf212140'
+      subtitle: AUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x8f3057b55256987fc921c90bbe8e273ab5c9a5ff19cf18d9b7c34238ab8befd5
+      description: >-
+        The PT-USDG-24SEP2026 is the asset used as collateral in a Morpho market
+        with AUSD as the loan token.
+    - chainId: 1
+      address: '0xc1906aecf868749a2dee203f59b904c0cf212140'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x2412afc9614939a5d994397fe0b94a4f6fb8bc02bfc139e1a5956a865e2efe26
+      description: >-
+        The PT-USDG-24SEP2026 is the asset used as collateral in a Morpho market
+        with USDC as the loan token.
+    - chainId: 1
+      address: '0xc1906aecf868749a2dee203f59b904c0cf212140'
+      subtitle: USDT
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x02bb03bf55f07c3ed3eee8a25d8df60fb9d09a38db612f0e07cf5c4d3df0100d
+      description: >-
+        The PT-USDG-24SEP2026 is the asset used as collateral in a Morpho market
+        with USDT as the loan token.
+    - chainId: 1
+      address: '0xc653f79de1274ee65674befda54986020d6f8fc1'
+      subtitle: WBTC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xddda840cba83c4b76c93d7fcdd2c4178914f98b2c9a38a7831b160ce116013c1
+      description: >-
+        The PT-EBTC-26JUN2025 is the asset used as collateral in a Morpho market
+        with WBTC as the loan token.
+    - chainId: 1
+      address: '0xc689f76f90fe1762fac55983ff25ae71033a84f7'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x4bb22a5f6313fc9d7b5e1438967bfcd0a513a839d26662dd8d235629942400e2
+      description: >-
+        The PT-sUSDat-27AUG2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0xd28b0d694b8e814fa905a8b480b30691e18396eb'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x4483b864209c50da2be8fc75371db0e92fdc6bc8920d86fc9b56ea7383f8c9d1
+      description: >-
+        The PT-apxUSD-27AUG2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0xd341a146a4fd20ea89898e4d86ae1829bf3a1c23'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97
+      description: >-
+        The PT-sUSDD-27AUG2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0xd341a146a4fd20ea89898e4d86ae1829bf3a1c23'
+      subtitle: USDT
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xdf6ca97d41975a6996e9db491cb38152b65d7c00807dfe15d95d8d76e5d122e0
+      description: >-
+        The PT-sUSDD-27AUG2026 is the asset used as collateral in a Morpho
+        market with USDT as the loan token.
+    - chainId: 1
+      address: '0xec5a52c685cc3ad79a6a347abace330d69e0b1ed'
+      subtitle: WBTC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xa39263bf7275f772863c464ef4e9e972aaa0f1a6a1bf2a47f92bf57a542d2458
+      description: >-
+        The PT-LBTC-27MAR2025 is the asset used as collateral in a Morpho market
+        with WBTC as the loan token.
+    - chainId: 1
+      address: '0xecfafdc7741323a945a163ed068b5a3c43483957'
+      subtitle: AUSD
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xea6abacc02dadfdb1bc2f4f1571da3fcb9c2b3028230d80fc71447a177cf4e99
+      description: >-
+        The PT-reUSD-10DEC2026 is the asset used as collateral in a Morpho
+        market with AUSD as the loan token.
+    - chainId: 1
+      address: '0xecfafdc7741323a945a163ed068b5a3c43483957'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x1e9d614631a7df0ec07fb05b2c8cb2491575fd1a63a33bf187a6afb295a4fc64
+      description: >-
+        The PT-reUSD-10DEC2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0xee5c7cda577484b70b65c21235ecbd302bb290e2'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0x62878115c6ee109c256237eb6daef589d006258202682d2e210cad3bb19e0f09
+      description: >-
+        The PT-apyUSD-27AUG2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 1
+      address: '0xffec096c087c13cc268497b89a613cace4df9a48'
+      subtitle: DAI
+      integrationUrl: >-
+        https://app.morpho.org/ethereum/market/0xa458018cf1a6e77ebbcc40ba5776ac7990e523b7cc5d0c1e740a4bbc13190d8f
+      description: >-
+        The PT-USDS-14AUG2025 is the asset used as collateral in a Morpho market
+        with DAI as the loan token.
+    - chainId: 130
+      address: '0x9d9874e867b877dd0a3f1eafb8bb1bc54eecc682'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/unichain/market/0x87a686cc100aabe917f8e1ad58140a1b63f0edbb9650a32c0526718dc610b2d5
+      description: >-
+        The PT-cUSD-23JUL2026-(ETH) is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 143
+      address: '0x9fc74f8ed616b5baf52a170caa97d6d3898602d1'
+      subtitle: mUSD
+      integrationUrl: >-
+        https://app.morpho.org/monad/market/0x71cad28b047d94c5a57c947619f9790b06b121536f975e03fdf241e9316edec7
+      description: >-
+        The PT-AUSD-8OCT2026 is the asset used as collateral in a Morpho market
+        with mUSD as the loan token.
     - chainId: 143
       address: '0x9fc74f8ed616b5baf52a170caa97d6d3898602d1'
       subtitle: USDC
@@ -176,5 +408,133 @@ metadata:
       description: >-
         The PT-AUSD-8OCT2026 is the asset used as collateral in a Morpho market
         with USDC as the loan token.
+    - chainId: 999
+      address: '0x311db0fde558689550c68355783c95efdfe25329'
+      subtitle: USD₮0
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0x888679b2af61343a4c7c0da0639fc5ca5fc5727e246371c4425e4d634c09e1f6
+      description: >-
+        The PT-kHYPE-13NOV2025 is the asset used as collateral in a Morpho
+        market with USD₮0 as the loan token.
+    - chainId: 999
+      address: '0x311db0fde558689550c68355783c95efdfe25329'
+      subtitle: USDHL
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0xe0a1de770a9a72a083087fe1745c998426aaea984ddf155ea3d5fbba5b759713
+      description: >-
+        The PT-kHYPE-13NOV2025 is the asset used as collateral in a Morpho
+        market with USDHL as the loan token.
+    - chainId: 999
+      address: '0x31a75680de78bb2787ffe9840da569dbdf4504f5'
+      subtitle: USD₮0
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0xfdece686f16877984325c7a1c192e0f18862bae3829d000a1a62b5bc2b31d4ef
+      description: >-
+        The PT-hbUSDT-18DEC2025 is the asset used as collateral in a Morpho
+        market with USD₮0 as the loan token.
+    - chainId: 999
+      address: '0x50fc4edc6346f36993bb30fe60e932504ed17391'
+      subtitle: USD₮0
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0x13843ab72bf739cd10ecea3188db81eeda2c6d6863108f40abc3e17e7ff78743
+      description: >-
+        The PT-kHYPE-24SEP2026 is the asset used as collateral in a Morpho
+        market with USD₮0 as the loan token.
+    - chainId: 999
+      address: '0x50fc4edc6346f36993bb30fe60e932504ed17391'
+      subtitle: WHYPE
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0xa13b394993cb7006f2202338fe8a02e88156dd145c1582b5cc466d8ca3a33854
+      description: >-
+        The PT-kHYPE-24SEP2026 is the asset used as collateral in a Morpho
+        market with WHYPE as the loan token.
+    - chainId: 999
+      address: '0xea84ca9849d9e76a78b91f221f84e9ca065fc9f5'
+      subtitle: USD₮0
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0x89fffba6e66db52690eed7aebe95d225388bd5c3c66950f759150e14d550cd86
+      description: >-
+        The PT-kHYPE-19MAR2026 is the asset used as collateral in a Morpho
+        market with USD₮0 as the loan token.
+    - chainId: 999
+      address: '0xea84ca9849d9e76a78b91f221f84e9ca065fc9f5'
+      subtitle: USD₮0
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0xa405d10deb61400d6caecf06f07f395759ad813b83e33c262c9eb48645526f5d
+      description: >-
+        The PT-kHYPE-19MAR2026 is the asset used as collateral in a Morpho
+        market with USD₮0 as the loan token.
+    - chainId: 999
+      address: '0xea84ca9849d9e76a78b91f221f84e9ca065fc9f5'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0xcd9898604b9b658fc3295f86d4cd7f02fa3a6b0a573879f1db9b83369f4951fb
+      description: >-
+        The PT-kHYPE-19MAR2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 999
+      address: '0xea84ca9849d9e76a78b91f221f84e9ca065fc9f5'
+      subtitle: USDH
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0xa1659a59340f097decd470d463a0f3657d38601ed5516bb70214c577c8dfa521
+      description: >-
+        The PT-kHYPE-19MAR2026 is the asset used as collateral in a Morpho
+        market with USDH as the loan token.
+    - chainId: 999
+      address: '0xea84ca9849d9e76a78b91f221f84e9ca065fc9f5'
+      subtitle: WHYPE
+      integrationUrl: >-
+        https://app.morpho.org/hyperevm/market/0x6243736b94609da57ca7cb399df512cfae8a112fa5a325d08fd5f4234f5ccd2c
+      description: >-
+        The PT-kHYPE-19MAR2026 is the asset used as collateral in a Morpho
+        market with WHYPE as the loan token.
+    - chainId: 8453
+      address: '0xc31e19dc6c8a90d628432e15bbd538aa8c789e5d'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/base/market/0xaf2657ed859dcac494afc20ba83e26fa153414da971a1f082ebfcb45d73955f1
+      description: >-
+        The PT-USDai-18JUN2026-(ARB) is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 42161
+      address: '0x07bc5bd6ce9a17f0e7aa91e0adbc9070dcb1d1de'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/arbitrum/market/0x50d1b741a63204ce27bdf17e5a9300800c350ecb9278d92d2292a5713ea227e6
+      description: >-
+        The PT-sUSDai-18JUN2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 42161
+      address: '0x1cdde40e29da213f42a7fa109ccadca372d9ee1b'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/arbitrum/market/0x958b40fcd0df023c156ec4a7eb8ffd47985b19d8bb02a36fb0af1bfc837fd605
+      description: >-
+        The PT-USDai-18JUN2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 42161
+      address: '0x1cdde40e29da213f42a7fa109ccadca372d9ee1b'
+      subtitle: USDT0
+      integrationUrl: >-
+        https://app.morpho.org/arbitrum/market/0x98225f86d3c0673d9b652b12f021f9bc6a09c9ca960680bea23c4de7e2a90f64
+      description: >-
+        The PT-USDai-18JUN2026 is the asset used as collateral in a Morpho
+        market with USDT0 as the loan token.
+    - chainId: 42161
+      address: '0xc9d24ad0bb25f34098e226a8c5192dea7bacccae'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/arbitrum/market/0x97cb4b88a7a5e8e9c039b106374124e642395437ffc0ef93f2799343ad022985
+      description: >-
+        The PT-USDai-15OCT2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
+    - chainId: 42161
+      address: '0xe46271ecb1d5c7c5134868760f10c18b03021ef1'
+      subtitle: USDC
+      integrationUrl: >-
+        https://app.morpho.org/arbitrum/market/0xc8455ed78482f7ef016caf0127c7ffd5e643b3b83d08d43e242a63c12358f754
+      description: >-
+        The PT-thBILL-18JUN2026 is the asset used as collateral in a Morpho
+        market with USDC as the loan token.
   yt: []
   lp: []

--- a/protocols/morpho/script.md
+++ b/protocols/morpho/script.md
@@ -1,184 +1,249 @@
-// run this basic .ts script in a script.ts file with ts-node script.ts. the logs will correspond to the config.yaml file.
+// Morpho integration generator.
+//
+// Regenerates protocols/morpho/config.yaml from live data. Run it and copy the
+// stdout into config.yaml (stderr carries progress + loud warnings):
+//
+//   npx ts-node script.ts > config.yaml
+//
+// Chains are derived DYNAMICALLY from Pendle's getSupportChains endpoint
+// intersected with Morpho's own supported-chain list — there is no hardcoded
+// chain array to maintain. When Pendle (or Morpho) launches a new chain, its
+// PT-collateral markets flow in automatically. The ONLY per-chain lookup left is
+// the app.morpho.org URL slug (MORPHO_CHAIN_SLUG); a listed PT market on an
+// unmapped chain is skipped LOUDLY (never emitted with a guessed slug) so the
+// gap surfaces in review instead of shipping a broken link.
 
-// run this basic .ts script in a script.ts file with ts-node script.ts. the logs will correspond to the config.yaml file.
+import * as yaml from 'js-yaml';
 
-interface Market {
-uniqueKey: string;
-whitelisted: boolean;
-collateralAsset: {
-address: string;
-symbol: string;
-priceUsd: number | null;
-chain: { network: string };
-} | null;
-loanAsset: {
-address: string;
-symbol: string;
-priceUsd: number | null;
-chain: { network: string };
-} | null;
-state: {
-supplyAssetsUsd: number;
-collateralAssetsUsd: number;
+const PENDLE_CHAINS_URL =
+  'https://api-v2.pendle.finance/core/v1/chains?includeAdditional=true';
+const PENDLE_ASSETS_URL =
+  'https://api-v2.pendle.finance/core/v1/querier/simplified-data';
+const MORPHO_GRAPHQL = 'https://blue-api.morpho.org/graphql';
+
+// Collateral explicitly excluded from the registry (carried over from the
+// previous generator).
+const EXCLUDED_COLLATERAL = '0xd0097149aa4cc0d0e1fc99b8bd73fc17dc32c1e9';
+
+// chainId -> app.morpho.org URL slug. Mirrors MORPHO_CHAINID_MAP in
+// pendle-backend-v2 (apps/sync/src/external-protocol/protocols/morpho/
+// morpho.protocol.ts), the authoritative slug source. Unlike the backend, an
+// unmapped chain is skipped loudly here rather than defaulting to 'ethereum'.
+const MORPHO_CHAIN_SLUG: Record<number, string> = {
+  1: 'ethereum',
+  130: 'unichain',
+  143: 'monad',
+  999: 'hyperevm',
+  8453: 'base',
+  42161: 'arbitrum',
 };
+
+const DESCRIPTION_MAX = 120;
+
+interface MorphoMarket {
+  marketId: string;
+  listed: boolean;
+  collateralAsset: {
+    address: string;
+    symbol: string;
+    chain: { id: number };
+  } | null;
+  loanAsset: { symbol: string } | null;
 }
 
-interface GraphQLMarketsResponse {
-data: {
-markets: {
-items: Market[];
-};
-};
+interface PtRow {
+  chainId: number;
+  address: string;
+  subtitle: string;
+  integrationUrl: string;
+  description: string;
 }
 
-function isGraphQLMarketsResponse(
-value: unknown
-): value is GraphQLMarketsResponse {
-return (
-typeof value === "object" &&
-value !== null &&
-"data" in value &&
-typeof (value as any).data === "object" &&
-"markets" in (value as any).data &&
-typeof (value as any).data.markets === "object" &&
-"items" in (value as any).data.markets &&
-Array.isArray((value as any).data.markets.items)
-);
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.json() as Promise<T>;
 }
 
-export async function fetchPTData(): Promise<void> {
-let skip = 0;
-let hasMore = true;
-const collateralMarkets = new Map<string, string[]>();
-let allFilteredMarkets: Market[] = [];
+async function gqlQuery<T>(query: string): Promise<T> {
+  const body = await fetchJson<{ data: T; errors?: unknown }>(MORPHO_GRAPHQL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
+  if (body.errors) {
+    throw new Error(`Morpho GraphQL error: ${JSON.stringify(body.errors)}`);
+  }
+  return body.data;
+}
 
-console.log("name: Morpho");
-console.log("icon: logo.png");
-console.log("category: Money Market");
-console.log("metadata:");
-console.log(" pt:");
+// Pendle's supported chains — the dynamic chain universe (getSupportChains).
+async function getSupportedChainIds(): Promise<number[]> {
+  const { chainIds } = await fetchJson<{ chainIds: number[] }>(
+    PENDLE_CHAINS_URL,
+  );
+  if (!Array.isArray(chainIds) || chainIds.length === 0) {
+    throw new Error('getSupportChains returned an empty/invalid chain list');
+  }
+  return chainIds;
+}
 
-// First pass: collect all markets
-while (hasMore) {
-const query = `           query {
-              markets(first: 100, skip: ${skip}, where: { chainId_in: [1, 8453] }, orderBy: BorrowAssetsUsd, orderDirection: Desc) {
-                items {
-                  uniqueKey
-                  whitelisted
-                  collateralAsset {
-                    address
-                    symbol
-                    priceUsd
-                    chain {
-                      network
-                    }
-                  }
-                  loanAsset {
-                    symbol
-                  }
-                }
-              }
-            }
-      `;
+// The exact PT set validate-config.js checks against — guarantees CI parity.
+async function getPendlePtSet(): Promise<Set<string>> {
+  const { data } = await fetchJson<{
+    data: Array<{
+      chainId: number;
+      pts?: string[];
+      crossPts?: Array<{ spokePt: string }>;
+    }>;
+  }>(PENDLE_ASSETS_URL);
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error('simplified-data returned an empty/invalid asset list');
+  }
+  const set = new Set<string>();
+  for (const { chainId, pts, crossPts } of data) {
+    (pts ?? []).forEach((pt) => set.add(`${chainId}-${pt.toLowerCase()}`));
+    (crossPts ?? []).forEach((c) =>
+      set.add(`${chainId}-${c.spokePt.toLowerCase()}`),
+    );
+  }
+  return set;
+}
 
-    try {
-      const response = await fetch("https://blue-api.morpho.org/graphql", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ query }),
-      });
+// Morpho errors on unknown chainIds, so we query only the intersection.
+async function getMorphoChainIds(): Promise<number[]> {
+  const data = await gqlQuery<{ chains: Array<{ id: number }> }>(
+    '{ chains { id } }',
+  );
+  return data.chains.map((c) => c.id);
+}
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const responseData: unknown = await response.json();
-      if (!isGraphQLMarketsResponse(responseData)) {
-        throw new Error("Unexpected API response structure");
-      }
-
-      const markets = responseData.data.markets.items;
-      const filteredMarkets = markets.filter(
-        (market) =>
-          market.whitelisted &&
-          market.loanAsset &&
-          market.collateralAsset?.symbol?.toLowerCase().startsWith("pt-") &&
-          market.collateralAsset?.address.toLowerCase() !==
-            "0xd0097149aa4cc0d0e1fc99b8bd73fc17dc32c1e9"
-      );
-
-      // Store filtered markets and update collateralMarkets map
-      filteredMarkets.forEach((market) => {
-        if (!market.collateralAsset || !market.loanAsset) return;
-
-        const collateralAddress = market.collateralAsset.address.toLowerCase();
-        if (!collateralMarkets.has(collateralAddress)) {
-          collateralMarkets.set(collateralAddress, []);
+async function fetchMorphoMarkets(chainIds: number[]): Promise<MorphoMarket[]> {
+  const all: MorphoMarket[] = [];
+  let skip = 0;
+  for (;;) {
+    const data = await gqlQuery<{ markets: { items: MorphoMarket[] } }>(`query {
+      markets(first: 100, skip: ${skip}, where: { chainId_in: [${chainIds.join(
+        ',',
+      )}] }, orderBy: BorrowAssetsUsd, orderDirection: Desc) {
+        items {
+          marketId
+          listed
+          collateralAsset { address symbol chain { id } }
+          loanAsset { symbol }
         }
-        collateralMarkets.get(collateralAddress)?.push(market.uniqueKey);
-      });
+      }
+    }`);
+    const items = data.markets.items;
+    all.push(...items);
+    if (items.length < 100) break;
+    skip += 100;
+  }
+  return all;
+}
 
-      allFilteredMarkets.push(...filteredMarkets);
-      skip += 100;
-      hasMore = markets.length === 100;
-    } catch (error) {
-      console.error("Error fetching markets:", error);
-      break;
+function buildRows(markets: MorphoMarket[], ptSet: Set<string>): PtRow[] {
+  const rows: PtRow[] = [];
+  const skippedChains = new Set<number>();
+
+  for (const m of markets) {
+    const ca = m.collateralAsset;
+    if (!m.listed || !ca || !m.loanAsset) continue;
+    if (!/^pt-/i.test(ca.symbol ?? '')) continue;
+
+    const address = ca.address.toLowerCase();
+    if (address === EXCLUDED_COLLATERAL) continue;
+
+    // chainId comes straight from chain.id — never defaulted to Ethereum.
+    const chainId = ca.chain?.id;
+    if (typeof chainId !== 'number') continue;
+
+    // CI parity: only emit PTs Pendle actually lists.
+    if (!ptSet.has(`${chainId}-${address}`)) continue;
+
+    const slug = MORPHO_CHAIN_SLUG[chainId];
+    if (!slug) {
+      skippedChains.add(chainId);
+      continue;
     }
 
-}
-
-// Sort all markets by collateral asset address and output
-allFilteredMarkets
-.sort((a, b) => {
-const addressA = a.collateralAsset?.address.toLowerCase() || "";
-const addressB = b.collateralAsset?.address.toLowerCase() || "";
-return addressA.localeCompare(addressB);
-})
-.forEach((market) => {
-if (!market.collateralAsset || !market.loanAsset) return;
-
-      if (
-        market.collateralAsset.address.toLowerCase() ===
-        "0xd0097149aa4cc0d0e1fc99b8bd73fc17dc32c1e9"
-      )
-        return;
-
-      const chainId =
-        market.collateralAsset.chain.network.toLowerCase() === "ethereum"
-          ? 1
-          : 8453;
-
-      console.log(`    - chainId: ${chainId}`);
-      console.log(`      address: "${market.collateralAsset.address}"`);
-
-      const collateralAddress = market.collateralAsset.address.toLowerCase();
-      const marketsCount =
-        collateralMarkets.get(collateralAddress)?.length || 0;
-      if (marketsCount > 1) {
-        console.log(`      subtitle: ${market.loanAsset.symbol}`);
-      }
-
-      console.log(
-        `      integrationUrl: https://app.morpho.org/market?id=${
-          market.uniqueKey
-        }&network=${chainId === 1 ? "mainnet" : "base"}`
+    const loan = m.loanAsset.symbol;
+    const description = `The ${ca.symbol} is the asset used as collateral in a Morpho market with ${loan} as the loan token.`;
+    if (description.length > DESCRIPTION_MAX) {
+      console.error(
+        `WARN description >${DESCRIPTION_MAX} chars, skipped: ${ca.symbol}/${loan}`,
       );
-      console.log(`      description: >-`);
-      console.log(
-        `        The ${market.collateralAsset.symbol} is the asset used as collateral in a Morpho`
-      );
-      console.log(
-        `        market with ${market.loanAsset.symbol} as the loan token.`
-      );
+      continue;
+    }
+
+    rows.push({
+      chainId,
+      address,
+      subtitle: loan,
+      integrationUrl: `https://app.morpho.org/${slug}/market/${m.marketId}`,
+      description,
     });
+  }
 
-console.log(" yt: []");
-console.log(" lp: []");
+  if (skippedChains.size) {
+    console.error(
+      `WARN listed PT markets on unmapped chain(s) skipped (add to MORPHO_CHAIN_SLUG): ${[
+        ...skippedChains,
+      ].join(', ')}`,
+    );
+  }
+
+  // Deterministic ordering for stable diffs.
+  rows.sort(
+    (a, b) =>
+      a.chainId - b.chainId ||
+      a.address.localeCompare(b.address) ||
+      a.subtitle.localeCompare(b.subtitle) ||
+      a.integrationUrl.localeCompare(b.integrationUrl),
+  );
+  return rows;
 }
 
-fetchPTData().then(() => {
-// Done
+async function main(): Promise<void> {
+  const [pendleChains, ptSet, morphoChains] = await Promise.all([
+    getSupportedChainIds(),
+    getPendlePtSet(),
+    getMorphoChainIds(),
+  ]);
+
+  const morphoSet = new Set(morphoChains);
+  const queryChains = pendleChains.filter((c) => morphoSet.has(c));
+  if (queryChains.length === 0) {
+    throw new Error('No overlap between Pendle and Morpho supported chains');
+  }
+  console.error(`Querying Morpho on chains: ${queryChains.join(', ')}`);
+
+  const markets = await fetchMorphoMarkets(queryChains);
+  const pt = buildRows(markets, ptSet);
+  console.error(
+    `Emitted ${pt.length} PT rows across chains ${[
+      ...new Set(pt.map((r) => r.chainId)),
+    ].join(', ')}`,
+  );
+
+  const config = {
+    name: 'Morpho',
+    icon: 'logo.png',
+    category: 'Money Market',
+    url: 'https://app.morpho.org/ethereum/borrow',
+    description:
+      'A permissionless and non-custodial lending protocol where users can earn interest on over-collaterized lending and borrow digital assets using immutable infrastructure.',
+    metadata: { pt, yt: [], lp: [] },
+  };
+
+  process.stdout.write(
+    yaml.dump(config, { lineWidth: 80, sortKeys: false, quotingType: "'" }),
+  );
+}
+
+// Fail loud: on any error, write nothing to stdout so a partial/empty config is
+// never produced.
+main().catch((err) => {
+  console.error('GENERATION FAILED (no output written):', err.message);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary

Makes the **Morpho** and **Aave** protocol registries self-maintaining: instead of hardcoding chains chain-by-chain (Morpho) or hand-typing markets (Aave), both `config.yaml` files are now produced by a `script.md` generator that derives its chain universe **dynamically** from Pendle's `getSupportChains` endpoint (`GET /core/v1/chains?includeAdditional=true`). New Pendle-supported chains and markets flow in automatically.

Every emitted PT is cross-checked against the same `simplified-data` list the CI validator uses, so generated output is CI-safe by construction, and every generator **fails loud** (writes nothing) on an API error or empty response rather than shipping a partial/empty registry.

## What changed

### Morpho (`protocols/morpho/`)
- Chain set = `getSupportChains` ∩ Morpho's own `chains` query — no more hardcoded `[1, 8453]`.
- Migrated to Morpho's **current** GraphQL schema: `listed` (was `whitelisted`), `marketId` (was `uniqueKey`), `chain { id }`.
- Removed the silent network-name→chainId default that mapped unmatched chains to Ethereum; unmapped URL slugs are now skipped **loudly** (slug map mirrors the backend's `MORPHO_CHAINID_MAP`).
- Regenerated `config.yaml`: **66 rows**, auto-discovering HyperEVM and Base markets. **All 16 previously-listed markets preserved (0 dropped).**

### Aave (`protocols/aave/`)
- New generator covering **both Aave v3 and v4**.
  - **v3** (`api.v3.aave.com`): full `markets` schema — symbols, collateral/borrow flags. URL: `app.aave.com/reserve-overview`.
  - **v4** (`api.v4.aave.com`): hub/spoke model whose GraphQL exposes **no token symbols**, so symbols are resolved from the v3 reserves + Pendle's asset registry (`assets/all`); an unresolvable token is skipped loudly. URL: `pro.aave.com/explore/reserve/{id}` (the reserve `id` is the app's route param).
- One row per PT collateral × major borrowable stablecoin (`STABLE_BORROW` set), matching the previous config's shape.
- Regenerated `config.yaml`: **39 rows** across Ethereum + Plasma (v3) and the Ethena / USDG-Pendle spokes (v4).
- **Note:** the two PTs in the old config (`0x59bc9f…`, `0xf7fb83…`) are dropped — Aave has since set them `canBeCollateral=false`, so the config was advertising integrations Aave has disabled. They're replaced by the currently-active collateral markets.

### Docs
- README notes that the Morpho and Aave configs are script-generated and should be regenerated rather than hand-edited.

## Testing

- Both protocols pass the repo's own `validate-config.js` against the live `simplified-data` list (the same check CI runs on PRs).
- `merge-config.js` produces a valid `config.json` including both protocols (not committed — CI regenerates it).
- Generators run end-to-end against the live Morpho / Aave / Pendle APIs; output validated for schema, description ≤120 / subtitle ≤20 limits, and no dropped live Morpho markets.

## Known considerations

- The Aave v4 API is new and undocumented (introspection disabled); the generator reverse-engineers its schema and depends on symbol resolution via v3 + Pendle's registry. If Aave changes the v4 schema, regeneration will fail loud rather than emit bad data.
- `STABLE_BORROW` (Aave) and `MORPHO_CHAIN_SLUG` / `AAVE_V3_MARKET_NAME` are small, clearly-marked constants; a new chain/market surfaces a loud warning prompting a one-line addition rather than silently dropping data.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this repo only produces static registry data consumed downstream via the auto-generated `config.json`. Validation is the CI `validate-config.js` gate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
